### PR TITLE
Add web support

### DIFF
--- a/lib/src/scroll_app_bar_controller.dart
+++ b/lib/src/scroll_app_bar_controller.dart
@@ -3,6 +3,8 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:scroll_bars_common/scroll_bars_common.dart';
 
+import 'package:flutter/foundation.dart' show kIsWeb;
+
 extension ScrollAppBarControllerExt on ScrollController {
   static final _controllers = <int, _ScrollAppBarController>{};
 
@@ -21,5 +23,5 @@ class _ScrollAppBarController extends ScrollBarsController {
         super(scrollController);
 
   @override
-  double height = kToolbarHeight + (Platform.isAndroid ? 24.0 : 0.0);
+  double height = kToolbarHeight + (kIsWeb ? 0.0 : Platform.isAndroid ? 24.0 : 0.0);
 }


### PR DESCRIPTION
Hi @edsonbonfim, i had an error when running your library on web as you can see [here](https://imgur.com/a/ImehSEO).

I solved by adding **kIsWeb** control in _scroll_app_bar_controller.dart_ where you check **Platform.Android.**

Here is a pull request, hope it can be helpful.

Antonio.